### PR TITLE
Add support for brick/phonenumber:^0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.4.0 <8.3",
         "doctrine/dbal": "^2.13.3@dev || ^3.0@dev",
-        "brick/phonenumber": "^0.2@dev || ^0.3@dev || ^0.4@dev"
+        "brick/phonenumber": "^0.2@dev || ^0.3@dev || ^0.4@dev || ^0.5@dev"
     },
     "require-dev": {
         "nette/tester": "2.4.3",


### PR DESCRIPTION
Since there is a new release with no (real) BC breaks (see https://github.com/brick/phonenumber/releases/tag/0.5.0) 